### PR TITLE
Removed the Tucson Off Coal Event

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,20 +66,6 @@
         </div>
         
         <div class="content">
-
-            <h2>The Future of TEP and Our Climate</h2>
-            <img src="https://i.imgur.com/UAJfL1q.jpg" title="source: imgur.com" />
-            <p>Wed, Dec 13, 2023; 6:00 PM - 7:30 PM  (Mountain)</p>
-            <p>Organized By: Sierra Club - Grand Canyon Chapter</p>
-            <p>Location: 738 N 5th Ave, Tucson, AZ 85705, USA</p>
-            <p>Please join us at The Historic Y or via Zoom to learn how Tucson Electric Power (TEP) is planning to provide fossil fuel based electricity for the next 15 years and how that plan contradicts what needs to happen to avoid the worst effects of the climate calamity we are facing as a planet, per the newest UN report. </p>
-
-            <p>Raise your voice and send a message to TEP and the Arizona Corporation Commission (ACC) supporting a quick, just transition to clean energy in Tucson!</p>
-
-            <p>There will be food!</p>
-            
-            <p><a href="https://act.sierraclub.org/events/details?formcampaignid=7013q000002HhALAA0">RSVP Here</a></p>
-            
             
             <h2>Mission Statement</h2>
             <p>GTCC's mission is to create a unifying voice in the community, representing our full diversity, for climate policies and action to achieve electrification, decarbonization, energy efficiency and adaptation to climate impacts in our region.</p>


### PR DESCRIPTION
Removed the Tucson Off Coal Event because it is now in the past. 